### PR TITLE
for recipes which use the invalidate_build_funcs feature disable the …

### DIFF
--- a/scripts/build_functions/package_build_functions.rb
+++ b/scripts/build_functions/package_build_functions.rb
@@ -54,7 +54,9 @@ module PackageBuildFunctions
         def compile_and_link_prepare
             if src_files_prepared.empty?
                 @src_files_prepared = srcs.map { |e| "#{get_pkg_work_dir}/#{e}" }
-                @obj_files_prepared = srcs.map { |e| "#{get_pkg_work_dir}/#{get_uri_without_extension(e)}.#{global_config.get_obj_extension}" }
+                if @use_default_obj_linking == true
+                    @obj_files_prepared = srcs.map { |e| "#{get_pkg_work_dir}/#{get_uri_without_extension(e)}.#{global_config.get_obj_extension}" }
+                end
             end
         end
 

--- a/scripts/package.rb
+++ b/scripts/package.rb
@@ -86,6 +86,10 @@ module PackageDescriptor
         attr_reader :global_defines
         attr_reader :global_linker_flags
 
+        # For all packages that want to prepare src files locally, but don't want to
+        # use the default linking of objects in the end
+        attr_reader :use_default_obj_linking
+
         attr_reader :instance_var_to_reset
 
         # pkg_work_dir: work directory
@@ -229,6 +233,8 @@ module PackageDescriptor
             @global_defines = []
             @global_linker_flags = []
 
+            @use_default_obj_linking = true;
+
             @instance_var_to_reset = []
         end
 
@@ -299,6 +305,10 @@ class SoftwarePackage
         end
 
         def invalidate_build_funcs
+            # Don't use default linking of objects for
+            # recipes which override build funcs
+            @use_default_obj_linking = false
+
             self.override_func :do_compile_clean do
                 print_abort("not implemented")
             end


### PR DESCRIPTION
…default

linking of objects.

This is useful for recipes that don't want to use the default build functions but still want to have local source files prepared automatically in the build folder.